### PR TITLE
Limit buffered media to prevent memory growth

### DIFF
--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -2,6 +2,9 @@
 import React, { useEffect, useRef, useState } from "react";
 import MP4Box from "mp4box";
 
+// Maximum amount of buffered media to keep (seconds)
+const MAX_BUFFER_SECONDS = 30;
+
 /**
  * Props
  * ───────────────────────────────────────────────────────────
@@ -118,14 +121,22 @@ export default function VideoPlayer({
         sb.addEventListener("updateend", () => {
           pump(t.id);
 
+          const buffered = sb.buffered;
+          if (
+            buffered.length &&
+            buffered.end(0) - buffered.start(0) > MAX_BUFFER_SECONDS
+          ) {
+            sb.remove(0, buffered.end(0) - MAX_BUFFER_SECONDS);
+          }
+
           /* seek to live edge once first video data buffered */
           if (
             !haveSeeked &&
             t.type === "video" &&
-            sb.buffered.length &&
-            sb.buffered.end(sb.buffered.length - 1) > 0
+            buffered.length &&
+            buffered.end(buffered.length - 1) > 0
           ) {
-            const edge = sb.buffered.end(sb.buffered.length - 1);
+            const edge = buffered.end(buffered.length - 1);
             videoRef.current.currentTime = edge - 0.3;
             videoRef.current
               .play()


### PR DESCRIPTION
## Summary
- Add configurable `MAX_BUFFER_SECONDS` constant to VideoPlayer
- Trim old SourceBuffer data when buffered duration exceeds limit

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb5cc56f88330b8d5ef8391720edc